### PR TITLE
Do not allow create org if missing

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -140,7 +140,7 @@ func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName,
 	} else {
 		// ensure the org exists.
 		createRepoOrgName = ownerName
-		_, err := getOrCreateGitHubOrg(ctx, client, ownerName, *currentUser.Login)
+		_, err := getGitHubOrg(ctx, client, ownerName, *currentUser.Login)
 		if err != nil {
 			return nil, err
 		}

--- a/src/push.go
+++ b/src/push.go
@@ -161,20 +161,14 @@ func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName,
 	return ghRepo, nil
 }
 
-func getOrCreateGitHubOrg(ctx context.Context, client *github.Client, orgName, admin string) (*github.Organization, error) {
+func getGitHubOrg(ctx context.Context, client *github.Client, orgName, admin string) (*github.Organization, error) {
 	org := &github.Organization{Login: &orgName}
 
-	var getErr error
-	ghOrg, _, createErr := client.Admin.CreateOrg(ctx, org, admin)
-	if createErr == nil {
-		fmt.Printf("Created organization `%s` (admin: %s)\n", orgName, admin)
-	} else {
-		// Regardless of why create failed, see if we can retrieve the org
-		ghOrg, _, getErr = client.Organizations.Get(ctx, orgName)
+	ghOrg, _, getErr = client.Organizations.Get(ctx, orgName)
+	if getErr != nil {
+		return nil, errors.Wrapf(getErr, "error getting organization %s", orgName)
 	}
-	if createErr != nil && getErr != nil {
-		return nil, errors.Wrapf(createErr, "error creating organization %s", orgName)
-	}
+
 	if ghOrg == nil {
 		return nil, errors.New("error organization is nil")
 	}


### PR DESCRIPTION
Due to permission and the way we mange Github CI centrally, only creating the Org manually first is allowed